### PR TITLE
Adding basic tasks and extensions to workspace

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"ms-vsliveshare.vsliveshare-pack",
+		"ms-python.python"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": []
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,69 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run tests",
+            "type": "shell",
+            "command": "${config:python.pythonPath}",
+            "args": [
+                "-m",
+                "unittest",
+                "discover"
+            ],
+            "group": "test",
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            }
+        },
+        {
+            "label": "Create Virtual Environment",
+            "type": "shell",
+            "command": "pip install virtualenv && virtualenv venv",
+            "windows": {
+                "command": "pip install virtualenv; virtualenv venv"
+            },
+            "group": "test",
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared"
+            }
+        },
+        {
+            "label": "Host Docs",
+            "type": "process",
+            "command": "python",
+            "args": [
+                "-m",
+                "http.server"
+            ],
+            "group": "test",
+            "presentation": {
+                "reveal": "silent",
+                "panel": "new"
+            },
+            "options": {
+                "cwd": "${workspaceRoot}/docs"
+            }
+        },
+        {
+            "label": "Build Docs",
+            "type": "shell",
+            "command": "${config:python.pythonPath}",
+            "args": [
+                "-m",
+                "sphinx",
+                ".docs",
+                "docs"
+            ],
+            "group": "test",
+            "presentation": {
+                "reveal": "never",
+                "panel": "shared",
+                "revealProblems": "onProblem"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Allows for the ability to easily stage the development environment using vscode tasks.

tasks created
- New Virtual Environment: installs virtualenv and uses to create venv at the root
- Run Tests: uses venv to run unittest discover
- Build Docs: uses sphinx to build docs targetting the docs directory
- Host Docs: creates a long running session hosting the documentation in the docs folder at localhost:8000